### PR TITLE
server: Add privacy authentication

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,6 +14,12 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@0auth/message": "^0.0.1"
+    "@0auth/message": "^0.0.1",
+    "crypto-js": "^4.0.0",
+    "elliptic": "^6.5.3"
+  },
+  "devDependencies": {
+    "@types/crypto-js": "^3.1.47",
+    "@types/elliptic": "^6.4.12"
   }
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,5 @@
-import {KeyType, Property, Signature} from "@0auth/message";
+import {AuthType, KeyType, Property, Signature} from "@0auth/message";
+import {getMerkleRoot, hashProperty, signAccordingToKeyType, verifyAccordingToKeyType} from "./utils";
 
 type SecretKey = {
   type: KeyType;
@@ -10,10 +11,10 @@ type PublicKey = {
   key: string;
 }
 
-// TODO: @ts-ignore should be removed, when below function is implemented.
-// @ts-ignore
 export function authPrivacy(properties: Property[], secret: SecretKey): Signature {
-  // TODO: Not implemented yet.
+  const hashes = properties.map(property => hashProperty(property)),
+    merkleRoot = getMerkleRoot(hashes);
+  return signAccordingToKeyType(merkleRoot, secret.key, secret.type);
 }
 
 // TODO: @ts-ignore should be removed, when below function is implemented.
@@ -22,10 +23,13 @@ export function authPackage(properties: Property[], secret: SecretKey): Signatur
   // TODO: Not implemented yet.
 }
 
-// TODO: @ts-ignore should be removed, when below function is implemented.
-// @ts-ignore
 export function verifyPrivacy(properties: Property[], sign: Signature, publicKey: PublicKey): boolean {
-  // TODO: Not implemented yet.
+  if (sign.authType !== AuthType.Privacy || sign.keyType !== publicKey.type)
+    return false;
+
+  const hashes = properties.map(property => hashProperty(property)),
+    merkleRoot = getMerkleRoot(hashes);
+  return verifyAccordingToKeyType(merkleRoot, sign.value, publicKey.key, publicKey.type);
 }
 
 // TODO: @ts-ignore should be removed, when below function is implemented.

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -1,0 +1,74 @@
+import sha256 from "crypto-js/sha256";
+import {AuthType, KeyType, Property, PropertyType, Signature} from "@0auth/message";
+import {ec as ECDSA, eddsa as EdDSA} from "elliptic";
+
+export function utf8ToBase64(str: string): string {
+  return Buffer.from(encodeURIComponent(str), "binary").toString("base64");
+}
+
+export function hashProperty(property: Property): string {
+  if (property.type == PropertyType.Hash)
+    return property.value;
+
+  return hash(utf8ToBase64(property.key)+":"+utf8ToBase64(property.value));
+}
+
+export function getMerkleRoot(properties: string[]): string {
+  if (properties.length == 1)
+    return properties[0];
+
+  let parentNodes = [];
+  for (let i = 0; i < properties.length-1; i += 2)
+    parentNodes.push(hash(properties[i]+properties[i+1]));
+
+  if (properties.length % 2 == 1)
+    parentNodes.push(properties[properties.length-1]);
+
+  return getMerkleRoot(parentNodes);
+}
+
+export function hash(msg: string): string {
+  return sha256(msg).toString();
+}
+
+export function signAccordingToKeyType(hash: string, secret: string, type: KeyType): Signature {
+  switch (type) {
+    case KeyType.ECDSA: {
+      const ecdsa = new ECDSA("secp256k1"),
+        key = ecdsa.keyFromPrivate(secret, "hex");
+      return {
+        authType: AuthType.Privacy,
+        keyType: KeyType.ECDSA,
+        value: key.sign(hash).toDER("hex")
+      }
+    }
+    case KeyType.EDDSA: {
+      const eddsa = new EdDSA("ed25519"),
+        key = eddsa.keyFromSecret(secret);
+      return {
+        authType: AuthType.Privacy,
+        keyType: KeyType.EDDSA,
+        value: key.sign(hash).toHex()
+      }
+    }
+    default:
+      throw new Error("Unreachable Code");
+  }
+}
+
+export function verifyAccordingToKeyType(hash: string, sign: string, publicKey: string, type: KeyType): boolean {
+  switch (type) {
+    case KeyType.ECDSA: {
+      const ecdsa = new ECDSA("secp256k1"),
+        key = ecdsa.keyFromPublic(publicKey, "hex");
+      return key.verify(hash, sign);
+    }
+    case KeyType.EDDSA: {
+      const eddsa = new EdDSA("ed25519"),
+        key = eddsa.keyFromPublic(publicKey);
+      return key.verify(hash, sign);
+    }
+    default:
+      throw new Error("Unreachable Code");
+  }
+}

--- a/packages/server/test/auth.spec.ts
+++ b/packages/server/test/auth.spec.ts
@@ -1,15 +1,134 @@
-describe("test privacy mode authentication", () => {
+import {expect} from "chai";
+import {authPrivacy, verifyPrivacy} from "../src";
+import {KeyType, Property, PropertyType} from "@0auth/message";
+import {ec as ECDSA, eddsa as EdDSA} from "elliptic";
+import {getMerkleRoot, hash, hashProperty, utf8ToBase64, verifyAccordingToKeyType} from "../src/utils";
 
+describe("test utils", () => {
+  it("test utf8 to base64", () => {
+    expect(utf8ToBase64("ABC")).to.be.equal("QUJD");
+    expect(utf8ToBase64("서울")).to.be.equal("JUVDJTg0JTlDJUVDJTlBJUI4");
+  });
+  it("test hash property", () => {
+    const property1: Property = {key: "a,b", type: PropertyType.Raw, value: "c"},
+      property2: Property = {key: "a", type: PropertyType.Raw, value: "b,c"},
+      property3: Property = {
+        key: "",
+        type: PropertyType.Hash,
+        value: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+      };
+
+    expect(hashProperty(property1)).to.be.equal("2e832436ce5b19a381949a13547469604758fd5e0001206f8a6cf0ed7974145a");
+    expect(hashProperty(property1)).to.be.not.equal(hashProperty(property2));
+    expect(hashProperty(property3)).to.be.equal(hashProperty(property3));
+  });
+  it("test hash", () => {
+    expect(hash("abc")).to.be.equal("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  });
+  it("test merkle root", () => {
+    const properties = Array.from(Array(100).keys())
+      .map(index => ({type: PropertyType.Raw, key: "key" + index, value: "value" + index}))
+      .map(property => hashProperty(property));
+    expect(getMerkleRoot(properties)).to.be.equal("5f51373a384a121a2d47a4c94c5e3e07ebb994a2f1db99190c2329d5b8e0a1b1");
+  });
+})
+
+describe("test privacy mode authentication", () => {
+  const properties: Property[] = [
+    {key: "name", type: PropertyType.Raw, value: "Kim"},
+    {key: "age", type: PropertyType.Raw, value: "17"},
+    {key: "address", type: PropertyType.Raw, value: "Seoul"}
+  ];
+  it("test ECDSA authentication", () => {
+    const ecdsa = new ECDSA("secp256k1"),
+      key1 = ecdsa.keyFromPrivate("2ef40452ec154cd38efdc8ffa52e7f513f7d2b2a77e028342bde96c369e4f77a"),
+      key2 = ecdsa.keyFromPrivate("f351840fba553b777dcdd76b410b37924ffc0a1f2876be5b52440397b15ab6ab"),
+      hashes = properties.map(property => hashProperty(property)),
+      merkleRoot = getMerkleRoot(hashes),
+      sign = authPrivacy(properties, {key: key1.getPrivate("hex"), type: KeyType.ECDSA});
+
+    expect(key1.verify(merkleRoot, sign.value)).to.be.equal(true);
+    expect(key2.verify(merkleRoot, sign.value)).to.be.equal(false);
+    expect(verifyAccordingToKeyType(merkleRoot, sign.value, key1.getPublic("hex"), KeyType.ECDSA)).to.be.equal(true);
+    expect(verifyAccordingToKeyType(merkleRoot, sign.value, key2.getPublic("hex"), KeyType.ECDSA)).to.be.equal(false);
+    expect(verifyPrivacy(properties, sign, {key: key1.getPublic("hex"), type: KeyType.ECDSA})).to.be.equal(true);
+    expect(verifyPrivacy(properties, sign, {key: key2.getPublic("hex"), type: KeyType.ECDSA})).to.be.equal(false);
+  });
+  it("test EdDSA authentication", () => {
+    const eddsa = new EdDSA("ed25519"),
+      key1 = eddsa.keyFromSecret("2ef40452ec154cd38efdc8ffa52e7f513f7d2b2a77e028342bde96c369e4f77a"),
+      key2 = eddsa.keyFromSecret("f351840fba553b777dcdd76b410b37924ffc0a1f2876be5b52440397b15ab6ab"),
+      hashes = properties.map(property => hashProperty(property)),
+      merkleRoot = getMerkleRoot(hashes),
+      sign = authPrivacy(properties, {key: key1.getSecret("hex"), type: KeyType.EDDSA});
+
+    expect(key1.verify(merkleRoot, sign.value)).to.be.equal(true);
+    expect(key2.verify(merkleRoot, sign.value)).to.be.equal(false);
+    expect(verifyAccordingToKeyType(merkleRoot, sign.value, key1.getPublic("hex"), KeyType.EDDSA)).to.be.equal(true);
+    expect(verifyAccordingToKeyType(merkleRoot, sign.value, key2.getPublic("hex"), KeyType.EDDSA)).to.be.equal(false);
+    expect(verifyPrivacy(properties, sign, {key: key1.getPublic("hex"), type: KeyType.EDDSA})).to.be.equal(true);
+    expect(verifyPrivacy(properties, sign, {key: key2.getPublic("hex"), type: KeyType.EDDSA})).to.be.equal(false);
+  });
+  it("test when the key type of signature and public key is different", () => {
+    const ecdsa = new ECDSA("secp256k1"),
+      eddsa = new EdDSA("ed25519"),
+      key1 = ecdsa.keyFromPrivate("2ef40452ec154cd38efdc8ffa52e7f513f7d2b2a77e028342bde96c369e4f77a"),
+      key2 = eddsa.keyFromSecret("2ef40452ec154cd38efdc8ffa52e7f513f7d2b2a77e028342bde96c369e4f77a"),
+      hashes = properties.map(property => hashProperty(property)),
+      merkleRoot = getMerkleRoot(hashes),
+      sign = authPrivacy(properties, {key: key1.getPrivate("hex"), type: KeyType.ECDSA});
+
+    expect(() => key2.verify(merkleRoot, sign.value)).to.throw("Assertion failed");
+    expect(() => verifyAccordingToKeyType(merkleRoot, sign.value, key2.getPublic("hex"), KeyType.EDDSA)).to.throw("Assertion failed");
+    expect(verifyPrivacy(properties, sign, {key: key2.getPublic("hex"), type: KeyType.EDDSA})).to.be.equal(false);
+  });
+  it("test if properties are different", () => {
+    const properties1: Property[] = [
+      {key: "a", type: PropertyType.Raw, value: "b,c"},
+      {key: "name", type: PropertyType.Raw, value: "Kim"},
+      {key: "age", type: PropertyType.Raw, value: "17"},
+      {key: "address", type: PropertyType.Raw, value: "Seoul"}
+    ];
+    const properties2: Property[] = [
+      {key: "a,b", type: PropertyType.Raw, value: "c"},
+      {key: "name", type: PropertyType.Raw, value: "Kim"},
+      {key: "age", type: PropertyType.Raw, value: "17"},
+      {key: "address", type: PropertyType.Raw, value: "Seoul"}
+    ];
+    const ecdsa = new ECDSA("secp256k1"),
+      key = ecdsa.keyFromPrivate("2ef40452ec154cd38efdc8ffa52e7f513f7d2b2a77e028342bde96c369e4f77a"),
+      sign1 = authPrivacy(properties1, {key: key.getPrivate("hex"), type: KeyType.ECDSA}),
+      sign2 = authPrivacy(properties2, {key: key.getPrivate("hex"), type: KeyType.ECDSA});
+
+    expect(sign1).to.be.not.equal(sign2);
+  });
+  it("should Korean property", () => {
+    const properties: Property[] = [
+        {key: "이름", type: PropertyType.Raw, value: "김"},
+        {key: "나이", type: PropertyType.Raw, value: "25"},
+        {key: "주소", type: PropertyType.Raw, value: "서울"}
+      ],
+      ecdsa = new ECDSA("secp256k1"),
+      key = ecdsa.keyFromPrivate("2ef40452ec154cd38efdc8ffa52e7f513f7d2b2a77e028342bde96c369e4f77a"),
+      sign = authPrivacy(properties, {key: key.getPrivate("hex"), type: KeyType.ECDSA});
+
+    expect(verifyPrivacy(properties, sign, {key: key.getPublic("hex"), type: KeyType.ECDSA})).to.be.equal(true);
+  });
+  it("test Signature verification without some value", () => {
+    const properties2 = [
+        {key: "name", type: PropertyType.Hash, value: hashProperty(properties[0])},
+        {key: "age", type: PropertyType.Raw, value: "17"},
+        {key: "address", type: PropertyType.Hash, value: hashProperty(properties[2])}
+      ],
+      ecdsa = new ECDSA("secp256k1"),
+      key = ecdsa.keyFromPrivate("2ef40452ec154cd38efdc8ffa52e7f513f7d2b2a77e028342bde96c369e4f77a"),
+      sign = authPrivacy(properties, {key: key.getPrivate("hex"), type: KeyType.ECDSA});
+
+    expect(verifyPrivacy(properties, sign, {key: key.getPublic("hex"), type: KeyType.ECDSA})).to.be.equal(true);
+    expect(verifyPrivacy(properties2, sign, {key: key.getPublic("hex"), type: KeyType.ECDSA})).to.be.equal(true);
+  });
 })
 
 describe("test package mode authentication", () => {
-
-})
-
-describe("test privacy mode verification", () => {
-
-})
-
-describe("test package mode Verification", () => {
 
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    "moduleResolution": "node"
   },
   "exclude": [
     "node_modules/*",


### PR DESCRIPTION
# Summary <!-- Type "It closes #0000" to automatically close the issue -->
Property authentication and verification function implemented
using ECDSA and EdDSA signature algorithms.

In order not to reveal some values, a merkle tree is generated
and the root value is signed and authenticated.

- It closes #15

## How to Review? <!-- Please provide a self-review guide for all PRs -->

- Please refer to my self-review submitted as the review.

## Images <!-- Screenshot or GIF. It can be used in the release note. -->

## Further Work <!-- A smaller PR is better. Please paste the link of the new issue here -->
